### PR TITLE
Redircting definition of INVALID_LICENSE for isgx 1.9 driver

### DIFF
--- a/graphene-sgx.h
+++ b/graphene-sgx.h
@@ -18,6 +18,7 @@
 
 #if SDK_DRIVER_VERSION > KERNEL_VERSION(1, 8, 0)
 #include "linux-sgx-driver/sgx_user.h"
+#define SGX_INVALID_LICENSE SGX_INVALID_EINITTOKEN
 #else // 1.8
 #include "linux-sgx-driver/isgx_user.h"
 #endif 


### PR DESCRIPTION
This PR fixes the issue reported in https://github.com/oscarlab/graphene/issues/156, where the compilation of Graphene-SGX got the error when compiling with Intel SGX driver 1.9 version. 

The reason is the macro "SGX_INVALID_LICENSE" is changed to "SGX_INVALID_EINITTOKEN" in sgx driver 1.9. 

The PR redefines the macro when SGX driver is greater than 1.8.

