### PR TITLE
graphene-sgx.h: compatibility for 1.9

### DIFF
--- a/graphene-sgx.h
+++ b/graphene-sgx.h
@@ -26,12 +26,16 @@
 #include "linux-sgx-driver/isgx_user.h"
 #endif
 
-#if SDK_DRIVER_VERSION >= KERNEL_VERSION(2, 1, 0)
 /*
  * SGX_INVALID_LICENSE renamed to SGX_INVALID_EINITTOKEN in SGX driver 2.1:
  * https://github.com/intel/linux-sgx-driver/commit/a7997dafe184d7d527683d8d46c4066db205758d
  */
-#define SGX_INVALID_LICENSE SGX_INVALID_EINITTOKEN
+#ifndef SGX_INVALID_LICENSE
+# ifndef SGX_INVALID_EINITTOKEN
+#  error "sgx_user.h version mismatch? Please verify linux sgx driver version."
+# else
+#  define SGX_INVALID_LICENSE SGX_INVALID_EINITTOKEN
+# endif
 #endif
 
 #else // SDK_DRIVER_VERSION < KERNEL_VERSION(1, 8, 0)


### PR DESCRIPTION
This patch make it build with 1.9 with SGX_INVALID_EINITTOKEN.
It was renamed from SGX_INVALID_LICENSE to SGX_INVALID_EINITTOKEN.
the define is protected with version 2.1, but it causes 1.9 build
breakage. Remove version check.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-sgx-driver/3)
<!-- Reviewable:end -->
