### PR TITLE
Add DCAP functions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,9 +21,9 @@ Additionally, this repository contains the script ``link-intel-driver.py`` to fi
 required C header from the Intel SGX driver installed on the system. The supported versions of the
 Intel SGX driver are:
 
-- DCAP driver <https://github.com/intel/SGXDataCenterAttestationPrimitives>
+- DCAP driver, only versions 1.5- <https://github.com/intel/SGXDataCenterAttestationPrimitives>
+  (please note that the most recent master branch is known to be *incompatible* with Graphene)
 - Older out-of-tree non-DCAP driver, only versions 1.9+ <https://github.com/intel/linux-sgx-driver>
-
 
 To install the Graphene SGX driver, please run::
 

--- a/link-intel-driver.py
+++ b/link-intel-driver.py
@@ -38,6 +38,8 @@ def main():
 
     with open(this_header_path, 'a') as f:
         f.write('\n\n#ifndef ISGX_FILE\n#define ISGX_FILE "%s"\n#endif\n' % dev_path)
+        if dev_path == '/dev/sgx':
+            f.write('\n\n#ifndef SGX_DCAP\n#define SGX_DCAP 1\n#endif\n')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is related to [this PR](https://github.com/oscarlab/graphene/pull/978).
`link-intel-driver.py` checks if the given SGX driver is DCAP, and if so, `SGX_DCAP` is defined.

Also, `load.sh` runs different code depending on whether the driver is DCAP or not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-sgx-driver/7)
<!-- Reviewable:end -->
