### PR TITLE
Rewrite link-intel-driver.py in python3

### DIFF
--- a/link-intel-driver.py
+++ b/link-intel-driver.py
@@ -1,7 +1,6 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import sys, os, re, readline, subprocess
-
 
 isgx_repo    = 'https://github.com/intel/linux-sgx-driver.git'
 isgx_path    = os.getenv("ISGX_DRIVER_PATH")
@@ -9,21 +8,22 @@ isgx_version = os.getenv("ISGX_DRIVER_VERSION")
 
 try:
     # get the locations of directories
-    print "\n" + \
-          "*****************************************************************\n" + \
-          "Make sure you have downloaded and installed the Intel SGX driver \n" + \
-          "from " + isgx_repo + ".\n" + \
-          "*****************************************************************\n" + \
-          "\n"
+    print('''
+*****************************************************************"
+Make sure you have downloaded and installed the Intel SGX driver"
+from {0}."
+*****************************************************************
+
+'''.format(isgx_repo))
 
     while True:
         if not isgx_path:
-            isgx_path = os.path.expanduser(raw_input(
+            isgx_path = os.path.expanduser(input(
                 'Enter the Intel SGX driver directory (can be absolute/relative path, or start with ~ or ~USERNAME): '))
 
             # clone the repo if not exist
             if not os.path.exists(isgx_path):
-                iput = raw_input(
+                iput = input(
                     'directory {0} does not exist; clone the driver here? ([n]/y): '.format(isgx_path)).lower()
                 if iput == 'y':
                     subprocess.check_call('git clone {0} {1}'.format(isgx_repo, isgx_path), shell=True)
@@ -32,14 +32,13 @@ try:
             break
         if os.path.exists(isgx_path + '/isgx.h'):
             break
-        print '{0} is not a directory for the Intel SGX driver'.format(isgx_path)
+        print('{0} is not a directory for the Intel SGX driver'.format(isgx_path))
         isgx_path = None
-
 
     # get the driver version
     while True:
         if not isgx_version:
-            isgx_version = raw_input('Enter the driver version (default: 2.1+): ')
+            isgx_version = input('Enter the driver version (default: 2.1+): ')
         if not isgx_version:
             isgx_version_major = 2
             isgx_version_minor = 1
@@ -49,30 +48,24 @@ try:
             isgx_version_major = m.group(1)
             isgx_version_minor = m.group(2)
             break
-        print '{0} is not a valid version (x.xx)'.format(isgx_version)
+        print('{0} is not a valid version (x.xx)'.format(isgx_version))
         isgx_version = None
-
 
     # create a symbolic link called 'linux-sgx-driver'
     isgx_link = 'linux-sgx-driver'
-    print isgx_link + ' -> ' + isgx_path
+    print(isgx_link + ' -> ' + isgx_path)
     if os.path.exists(isgx_link):
         os.unlink(isgx_link)
     os.symlink(isgx_path, isgx_link)
 
-
     # create isgx_version.h
     with open('isgx_version.h', 'w') as versionfile:
-        print 'create isgx_version.h'
-        print >> versionfile, '#include <linux/version.h>'
-        print >> versionfile
-        print >> versionfile, '#define SDK_DRIVER_VERSION KERNEL_VERSION(' + \
-                              str(isgx_version_major) + ',' + \
-                              str(isgx_version_minor) + ',0)'
-        print >> versionfile, '#define SDK_DRIVER_VERSION_STRING "' + \
-                              str(isgx_version_major) + '.' + \
-                              str(isgx_version_minor) + '"'
+        print('create isgx_version.h')
+        print('''#include <linux/version.h>
+
+#define SDK_DRIVER_VERSION KERNEL_VERSION({0}, {1}, 0)
+#define SDK_DRIVER_VERSION_STRING "{0}.{1}"'''.format(isgx_version_major, isgx_version_minor), file=versionfile)
 
 except:
-    print 'uh-oh: {0}'.format(sys.exc_info()[0])
+    print('uh-oh: {0}'.format(sys.exc_info()[0]))
     exit(-1)


### PR DESCRIPTION
When creating a graphene development environment in container, it is
best to install the minimal packages. Currently, graphene has removed
the dependency on python2.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-sgx-driver/8)
<!-- Reviewable:end -->
