### PR TITLE
Makefile: add distclean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,8 @@ endif
 
 .PHONY: clean
 clean:
-	rm -vrf linux-sgx-driver isgx_version.h
 	rm -vrf *.o *.ko *.order *.symvers *.mod.c .tmp_versions .*o.cmd .cache.mk *.o.ur-safe
+
+.PHONY: distclean
+distclean: clean
+	rm -vrf linux-sgx-driver isgx_version.h


### PR DESCRIPTION
Since it's rare to upgrade sgx driver,
by clean target, not remove linux-sgx-driver and isgx_version.h
Introduce distclean target to remove them.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-sgx-driver/10)
<!-- Reviewable:end -->
