### PR TITLE
Make kernel<->user passed structs packed

### DIFF
--- a/graphene-sgx.h
+++ b/graphene-sgx.h
@@ -50,7 +50,7 @@
 
 struct gsgx_enclave_create {
 	uint64_t src;
-};
+} __packed;
 
 #define GSGX_ENCLAVE_ADD_PAGES_SKIP_EEXTEND	0x1
 #define GSGX_ENCLAVE_ADD_PAGES_REPEAT_SRC	0x2
@@ -61,13 +61,13 @@ struct gsgx_enclave_add_pages {
 	uint64_t user_addr;
 	uint64_t size;
 	uint64_t secinfo;
-};
+} __packed;
 
 struct gsgx_enclave_init {
 	uint64_t addr;
 	uint64_t sigstruct;
 	uint64_t einittoken;
-};
+} __packed;
 
 #endif /* SDK_DRIVER_VERSION < KERNEL_VERSION(1, 8, 0) */
 


### PR DESCRIPTION
This ensures that no information can leak in struct padding (this doesn't happen right now, it's rather to make introducing this bug in the future harder).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-sgx-driver/11)
<!-- Reviewable:end -->
