### PR TITLE
Add support for the DCAP SGX driver versions 1.6 and newer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,8 +21,8 @@ Additionally, this repository contains the script ``link-intel-driver.py`` to fi
 required C header from the Intel SGX driver installed on the system. The supported versions of the
 Intel SGX driver are:
 
-- DCAP driver, only versions 1.5- https://github.com/intel/SGXDataCenterAttestationPrimitives
-  (please note that the most recent master branch is known to be *incompatible* with Graphene)
+- DCAP driver, newer versions 1.6+ https://github.com/intel/SGXDataCenterAttestationPrimitives
+- DCAP driver, older versions 1.5- https://github.com/intel/SGXDataCenterAttestationPrimitives
 - Older out-of-tree non-DCAP driver, only versions 1.9+ https://github.com/intel/linux-sgx-driver
 
 To install the Graphene SGX driver, please run::

--- a/gsgx.h
+++ b/gsgx.h
@@ -23,14 +23,35 @@
 #define GSGX_FILE  "/dev/gsgx"
 #define GSGX_MINOR MISC_DYNAMIC_MINOR
 
-/* SGX_INVALID_LICENSE was renamed to SGX_INVALID_EINITTOKEN in SGX driver 2.1:
- *   https://github.com/intel/linux-sgx-driver/commit/a7997dafe184d7d527683d8d46c4066db205758d */
-#if !defined(SGX_INVALID_LICENSE) && !defined(SGX_INVALID_EINITTOKEN)
-#error "Cannot find SGX_INVALID_LICENSE nor SGX_INVALID_EINITTOKEN in Linux SGX Driver headers"
+/* Graphene needs the below subset of SGX instructions' return values */
+#ifndef SGX_INVALID_SIG_STRUCT
+#define SGX_INVALID_SIG_STRUCT  1
 #endif
 
-#if !defined(SGX_INVALID_LICENSE)
-#define SGX_INVALID_LICENSE SGX_INVALID_EINITTOKEN
+#ifndef SGX_INVALID_ATTRIBUTE
+#define SGX_INVALID_ATTRIBUTE   2
+#endif
+
+#ifndef SGX_INVALID_MEASUREMENT
+#define SGX_INVALID_MEASUREMENT 4
+#endif
+
+#ifndef SGX_INVALID_SIGNATURE
+#define SGX_INVALID_SIGNATURE   8
+#endif
+
+#ifndef SGX_INVALID_EINITTOKEN
+#define SGX_INVALID_EINITTOKEN  16
+#endif
+
+#ifndef SGX_INVALID_CPUSVN
+#define SGX_INVALID_CPUSVN      32
+#endif
+
+/* SGX_INVALID_LICENSE was renamed to SGX_INVALID_EINITTOKEN in SGX driver 2.1:
+ *   https://github.com/intel/linux-sgx-driver/commit/a7997dafe184d7d527683d8d46c4066db205758d */
+#ifndef SGX_INVALID_LICENSE
+#define SGX_INVALID_LICENSE     SGX_INVALID_EINITTOKEN
 #endif
 
 #endif /* __ARCH_GSGX_H__ */

--- a/link-intel-driver.py
+++ b/link-intel-driver.py
@@ -3,14 +3,17 @@
 import sys, os, shutil
 
 DRIVER_VERSIONS = {
-        'sgx_user.h':             '/dev/isgx',
-        'include/uapi/asm/sgx.h': '/dev/sgx',
+        'sgx_user.h':                 '/dev/isgx',
+        'include/uapi/asm/sgx.h':     '/dev/sgx',
+        'include/uapi/asm/sgx_oot.h': '/dev/sgx/enclave',
 }
 
 def find_intel_sgx_driver():
     """
     Graphene only needs one header from the Intel SGX Driver:
-      - include/uapi/asm/sgx.h for DCAP version of the driver
+      - include/uapi/asm/sgx_oot.h for DCAP 1.6+ version of the driver
+        (https://github.com/intel/SGXDataCenterAttestationPrimitives)
+      - include/uapi/asm/sgx.h for DCAP 1.5- version of the driver
         (https://github.com/intel/SGXDataCenterAttestationPrimitives)
       - sgx_user.h for non-DCAP, older version of the driver
         (https://github.com/intel/linux-sgx-driver)
@@ -38,8 +41,10 @@ def main():
 
     with open(this_header_path, 'a') as f:
         f.write('\n\n#ifndef ISGX_FILE\n#define ISGX_FILE "%s"\n#endif\n' % dev_path)
-        if dev_path == '/dev/sgx':
+        if dev_path == '/dev/sgx' or dev_path == '/dev/sgx/enclave':
             f.write('\n\n#ifndef SGX_DCAP\n#define SGX_DCAP 1\n#endif\n')
+        if dev_path == '/dev/sgx/enclave':
+            f.write('\n\n#ifndef SGX_DCAP_16_OR_LATER\n#define SGX_DCAP_16_OR_LATER 1\n#endif\n')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The DCAP SGX driver v1.6+ closely follows the in-kernel SGX driver v28+. This version changes the driver path to `/dev/sgx/enclave` and changes argument struct of the `SGX_IOC_ENCLAVE_ADD_PAGE` ioctl.

Closes #15.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-sgx-driver/16)
<!-- Reviewable:end -->
