### PR TITLE
Create file `libraries` containing `-lsgx_dcap_ql` for DCAP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Module.symvers
 modules.order
 .tmp_versions
 sgx.h
+libraries

--- a/README.rst
+++ b/README.rst
@@ -21,8 +21,8 @@ Additionally, this repository contains the script ``link-intel-driver.py`` to fi
 required C header from the Intel SGX driver installed on the system. The supported versions of the
 Intel SGX driver are:
 
-- DCAP driver, only versions 1.5- https://github.com/intel/SGXDataCenterAttestationPrimitives
-  (please note that the most recent master branch is known to be *incompatible* with Graphene)
+- DCAP driver, newer versions 1.6+ https://github.com/intel/SGXDataCenterAttestationPrimitives
+- DCAP driver, older versions 1.5- https://github.com/intel/SGXDataCenterAttestationPrimitives
 - Older out-of-tree non-DCAP driver, only versions 1.9+ https://github.com/intel/linux-sgx-driver
 
 To install the Graphene SGX driver, please run::

--- a/gsgx.h
+++ b/gsgx.h
@@ -23,14 +23,33 @@
 #define GSGX_FILE  "/dev/gsgx"
 #define GSGX_MINOR MISC_DYNAMIC_MINOR
 
+/* SGX leaf instruction return values */
+#define SGX_SUCCESS             0
+#define SGX_INVALID_SIG_STRUCT  1
+#define SGX_INVALID_ATTRIBUTE   2
+#define SGX_BLKSTATE            3
+#define SGX_INVALID_MEASUREMENT 4
+#define SGX_NOTBLOCKABLE        5
+#define SGX_PG_INVLD            6
+#define SGX_LOCKFAIL            7
+#define SGX_INVALID_SIGNATURE   8
+#define SGX_MAC_COMPARE_FAIL    9
+#define SGX_PAGE_NOT_BLOCKED    10
+#define SGX_NOT_TRACKED         11
+#define SGX_VA_SLOT_OCCUPIED    12
+#define SGX_CHILD_PRESENT       13
+#define SGX_ENCLAVE_ACT         14
+#define SGX_ENTRYEPOCH_LOCKED   15
+#define SGX_INVALID_EINITTOKEN  16
+#define SGX_PREV_TRK_INCMPL     17
+#define SGX_PG_IS_SECS          18
+#define SGX_INVALID_CPUSVN      32
+#define SGX_INVALID_ISVSVN      64
+#define SGX_UNMASKED_EVENT      128
+#define SGX_INVALID_KEYNAME     256
+
 /* SGX_INVALID_LICENSE was renamed to SGX_INVALID_EINITTOKEN in SGX driver 2.1:
  *   https://github.com/intel/linux-sgx-driver/commit/a7997dafe184d7d527683d8d46c4066db205758d */
-#if !defined(SGX_INVALID_LICENSE) && !defined(SGX_INVALID_EINITTOKEN)
-#error "Cannot find SGX_INVALID_LICENSE nor SGX_INVALID_EINITTOKEN in Linux SGX Driver headers"
-#endif
-
-#if !defined(SGX_INVALID_LICENSE)
-#define SGX_INVALID_LICENSE SGX_INVALID_EINITTOKEN
-#endif
+#define SGX_INVALID_LICENSE     SGX_INVALID_EINITTOKEN
 
 #endif /* __ARCH_GSGX_H__ */

--- a/gsgx.h
+++ b/gsgx.h
@@ -23,33 +23,35 @@
 #define GSGX_FILE  "/dev/gsgx"
 #define GSGX_MINOR MISC_DYNAMIC_MINOR
 
-/* SGX leaf instruction return values */
-#define SGX_SUCCESS             0
+/* Graphene needs the below subset of SGX instructions' return values */
+#ifndef SGX_INVALID_SIG_STRUCT
 #define SGX_INVALID_SIG_STRUCT  1
+#endif
+
+#ifndef SGX_INVALID_ATTRIBUTE
 #define SGX_INVALID_ATTRIBUTE   2
-#define SGX_BLKSTATE            3
+#endif
+
+#ifndef SGX_INVALID_MEASUREMENT
 #define SGX_INVALID_MEASUREMENT 4
-#define SGX_NOTBLOCKABLE        5
-#define SGX_PG_INVLD            6
-#define SGX_LOCKFAIL            7
+#endif
+
+#ifndef SGX_INVALID_SIGNATURE
 #define SGX_INVALID_SIGNATURE   8
-#define SGX_MAC_COMPARE_FAIL    9
-#define SGX_PAGE_NOT_BLOCKED    10
-#define SGX_NOT_TRACKED         11
-#define SGX_VA_SLOT_OCCUPIED    12
-#define SGX_CHILD_PRESENT       13
-#define SGX_ENCLAVE_ACT         14
-#define SGX_ENTRYEPOCH_LOCKED   15
+#endif
+
+#ifndef SGX_INVALID_EINITTOKEN
 #define SGX_INVALID_EINITTOKEN  16
-#define SGX_PREV_TRK_INCMPL     17
-#define SGX_PG_IS_SECS          18
+#endif
+
+#ifndef SGX_INVALID_CPUSVN
 #define SGX_INVALID_CPUSVN      32
-#define SGX_INVALID_ISVSVN      64
-#define SGX_UNMASKED_EVENT      128
-#define SGX_INVALID_KEYNAME     256
+#endif
 
 /* SGX_INVALID_LICENSE was renamed to SGX_INVALID_EINITTOKEN in SGX driver 2.1:
  *   https://github.com/intel/linux-sgx-driver/commit/a7997dafe184d7d527683d8d46c4066db205758d */
+#ifndef SGX_INVALID_LICENSE
 #define SGX_INVALID_LICENSE     SGX_INVALID_EINITTOKEN
+#endif
 
 #endif /* __ARCH_GSGX_H__ */

--- a/link-intel-driver.py
+++ b/link-intel-driver.py
@@ -48,7 +48,8 @@ def main():
 
     this_libraries_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'libraries')
     with open(this_libraries_path, 'w') as f:
-        if dev_path == '/dev/sgx' or dev_path == '/dev/sgx/enclave':
+        if (os.path.exists('/usr/lib/x86_64-linux-gnu/libsgx_dcap_ql.so') and
+                (dev_path == '/dev/sgx' or dev_path == '/dev/sgx/enclave')):
             f.write('-lsgx_dcap_ql')
         else:
             f.write('')  # don't need any additional libraries for old driver

--- a/link-intel-driver.py
+++ b/link-intel-driver.py
@@ -46,6 +46,12 @@ def main():
         if dev_path == '/dev/sgx/enclave':
             f.write('\n\n#ifndef SGX_DCAP_NEW\n#define SGX_DCAP_NEW 1\n#endif\n')
 
+    this_libraries_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'libraries')
+    with open(this_libraries_path, 'w') as f:
+        if dev_path == '/dev/sgx' or dev_path == '/dev/sgx/enclave':
+            f.write('-lsgx_dcap_ql')
+        else:
+            f.write('')  # don't need any additional libraries for old driver
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/link-intel-driver.py
+++ b/link-intel-driver.py
@@ -3,14 +3,17 @@
 import sys, os, shutil
 
 DRIVER_VERSIONS = {
-        'sgx_user.h':             '/dev/isgx',
-        'include/uapi/asm/sgx.h': '/dev/sgx',
+        'sgx_user.h':                 '/dev/isgx',
+        'include/uapi/asm/sgx.h':     '/dev/sgx',
+        'include/uapi/asm/sgx_oot.h': '/dev/sgx/enclave',
 }
 
 def find_intel_sgx_driver():
     """
     Graphene only needs one header from the Intel SGX Driver:
-      - include/uapi/asm/sgx.h for DCAP version of the driver
+      - include/uapi/asm/sgx_oot.h for DCAP 1.6+ version of the driver
+        (https://github.com/intel/SGXDataCenterAttestationPrimitives)
+      - include/uapi/asm/sgx.h for DCAP 1.5- version of the driver
         (https://github.com/intel/SGXDataCenterAttestationPrimitives)
       - sgx_user.h for non-DCAP, older version of the driver
         (https://github.com/intel/linux-sgx-driver)
@@ -38,8 +41,10 @@ def main():
 
     with open(this_header_path, 'a') as f:
         f.write('\n\n#ifndef ISGX_FILE\n#define ISGX_FILE "%s"\n#endif\n' % dev_path)
-        if dev_path == '/dev/sgx':
+        if dev_path == '/dev/sgx' or dev_path == '/dev/sgx/enclave':
             f.write('\n\n#ifndef SGX_DCAP\n#define SGX_DCAP 1\n#endif\n')
+        if dev_path == '/dev/sgx/enclave':
+            f.write('\n\n#ifndef SGX_DCAP_NEW\n#define SGX_DCAP_NEW 1\n#endif\n')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Platforms with DCAP do not use Google Protobuf to communicate with AESM service, in contrast to old-style EPID platforms. Instead DCAP platforms rely on SGX DCAP SDK pre-installed on the system, and all DCAP attestation functionality is encapsulated in a library `sgx_dcap_ql`. This PR informs Graphene that it must link against this new library on a DCAP platform.

This PR builds on top of #16. That PR must be merged first, and then this PR will be rebased.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-sgx-driver/17)
<!-- Reviewable:end -->
