### PR TITLE
Add explicit note about vulnerability in this driver

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,14 @@ Linux versions do not allow enabling this instruction from user land, thus the
 need for this driver. In the future, when support for it will be added to Linux,
 this driver won't be needed.
 
+**Warning: This module shouldn't be used on production as it introduces a local
+privilege escalation vulnerability. Enabling FSGSBASE properly is a much more
+complex task and most likely can't be achieved in an out-of-tree driver. If
+you're interested in having this feature in production, you should test the
+kernel patchset which is currently being upstreamed (the most recent version at
+the time of writing:
+https://lore.kernel.org/lkml/20200511045311.4785-1-sashal@kernel.org/)**
+
 Additionally, this repository contains the script ``link-intel-driver.py`` to
 find and copy the required C header from the Intel SGX driver installed on the
 system. The supported versions of the Intel SGX driver are:

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-******************************************
+*******************
 Graphene SGX Driver
-******************************************
+*******************
 
 *Graphene SGX Driver for use with the Graphene Library OS*
 
@@ -10,24 +10,28 @@ Graphene SGX Driver
 This helper repository serves two purposes:
 
 - It contains the sources of the Graphene SGX driver (the GSGX driver).
-- It extracts the required C header from the Intel SGX driver (copied as ``sgx.h``).
+- It extracts the required C header from the Intel SGX driver (copied as
+  ``sgx.h``).
 
-The Graphene SGX Driver is a Linux kernel module installed under ``/dev/gsgx``. Its sole purpose is
-to enable the ``FSGSBASE`` instruction in user space. Current Linux versions do not allow enabling
-this instruction from user land, thus the need for this driver. In the future, when support for it
-will be added to Linux, this driver won't be needed.
+The Graphene SGX Driver is a Linux kernel module installed under ``/dev/gsgx``.
+Its sole purpose is to enable the ``FSGSBASE`` instruction in user space. Current
+Linux versions do not allow enabling this instruction from user land, thus the
+need for this driver. In the future, when support for it will be added to Linux,
+this driver won't be needed.
 
-Additionally, this repository contains the script ``link-intel-driver.py`` to find and copy the
-required C header from the Intel SGX driver installed on the system. The supported versions of the
-Intel SGX driver are:
+Additionally, this repository contains the script ``link-intel-driver.py`` to
+find and copy the required C header from the Intel SGX driver installed on the
+system. The supported versions of the Intel SGX driver are:
 
-- DCAP driver, newer versions 1.6+ https://github.com/intel/SGXDataCenterAttestationPrimitives
-- DCAP driver, older versions 1.5- https://github.com/intel/SGXDataCenterAttestationPrimitives
-- Older out-of-tree non-DCAP driver, only versions 1.9+ https://github.com/intel/linux-sgx-driver
+- DCAP driver, newer versions 1.6+ (https://github.com/intel/SGXDataCenterAttestationPrimitives)
+- DCAP driver, older versions 1.5- (https://github.com/intel/SGXDataCenterAttestationPrimitives)
+- Older out-of-tree non-DCAP driver, only versions 1.9+ (https://github.com/intel/linux-sgx-driver)
 
-To install the Graphene SGX driver, please run::
+To install the Graphene SGX driver, please run:
 
-    sudo rmmod graphene_sgx || true  # for legacy driver (was previously named `graphene_sgx`)
-    sudo rmmod gsgx || true
-    make
-    sudo insmod gsgx.ko
+.. code-block:: sh
+
+   sudo rmmod graphene_sgx || true  # for legacy driver (was previously named `graphene_sgx`)
+   sudo rmmod gsgx || true
+   make
+   sudo insmod gsgx.ko

--- a/gsgx.c
+++ b/gsgx.c
@@ -83,6 +83,11 @@ static int __init gsgx_init(void) {
     int ret;
 
     pr_info(DRV_DESCRIPTION " v" DRV_VERSION "\n");
+    pr_crit("*************************************************************\n");
+    pr_crit("*** WARNING: This module should not be used in production ***\n");
+    pr_crit("*** as it allows local privilege escalation. For more     ***\n");
+    pr_crit("*** information see the included README.rst.              ***\n");
+    pr_crit("*************************************************************\n");
 
     if (!boot_cpu_has(X86_FEATURE_FSGSBASE)) {
         pr_err("FSGSBASE feature required by Graphene is not supported by this CPU!\n");


### PR DESCRIPTION
As correctly pointed out on LKML (["[PATCH v12 00/18] Enable FSGSBASE instructions" thread](https://lore.kernel.org/lkml/20200511045311.4785-1-sashal@kernel.org/)), we should be more explicit that this driver should be used only for testing or in dedicated VMs, because it introduces a local privilege escalation vuln. See the README diff for more info.

I'll also do a follow-up in the main repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-sgx-driver/20)
<!-- Reviewable:end -->
