### PR TITLE
Update gitignore and make clean for 5.7 kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.o.ur-safe
 *.ko
 *.mod.c
+*.mod
+*.mod.cmd
 Module.symvers
 modules.order
 .tmp_versions

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ endif
 
 .PHONY: clean
 clean:
-	$(RM) -r *.o *.ko *.order *.symvers *.mod.c .tmp_versions .*o.cmd .cache.mk *.o.ur-safe
+	$(RM) -r *.o *.ko *.order *.symvers *.mod.c .tmp_versions .*o.cmd .cache.mk *.o.ur-safe *.mod .gsgx.mod.cmd
 
 .PHONY: distclean
 distclean: clean


### PR DESCRIPTION
In testing on a 5.7 kernel, some new output files are not gitignored or cleaned up, namely:

	.gsgx.mod.cmd
	gsgx.mod

Clean these up properly so Jenkins passes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-sgx-driver/22)
<!-- Reviewable:end -->
