### PR TITLE
[Build] gitignore even more output from the build process on a 5.8 kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.o.cmd
 *.ko.cmd
+*.order.cmd
+*.symvers.cmd
 *.o
 *.o.ur-safe
 *.ko

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ endif
 
 .PHONY: clean
 clean:
-	$(RM) -r *.o *.ko *.order *.symvers *.mod.c .tmp_versions .*o.cmd .cache.mk *.o.ur-safe *.mod .gsgx.mod.cmd
+	$(RM) -r *.o *.ko *.order *.symvers *.mod.c .tmp_versions .*o.cmd .cache.mk *.o.ur-safe *.mod .gsgx.mod.cmd *.order.cmd *.symvers.cmd
 
 .PHONY: distclean
 distclean: clean


### PR DESCRIPTION
This came up in testing v13 of the FSGSBASE patch series.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-sgx-driver/24)
<!-- Reviewable:end -->
