### PR TITLE
Make clean on 5.8 kernel fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ endif
 
 .PHONY: clean
 clean:
-	$(RM) -r *.o *.ko *.order *.symvers *.mod.c .tmp_versions .*o.cmd .cache.mk *.o.ur-safe *.mod .gsgx.mod.cmd *.order.cmd *.symvers.cmd
+	$(RM) -r *.o *.ko *.order *.symvers *.mod.c .tmp_versions .*o.cmd .cache.mk *.o.ur-safe *.mod .gsgx.mod.cmd .modules.order.cmd .Module.symvers.cmd
 
 .PHONY: distclean
 distclean: clean


### PR DESCRIPTION
My last PR was a bit pre-mature - dot files are not matched with star.  To pass clean check Jenkins, we need to name these files in the target.  With this change, Jenkins does appear to pass on a patched 5.8 kernel.

The companion PR is: https://github.com/oscarlab/graphene/pull/1659

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-sgx-driver/25)
<!-- Reviewable:end -->
