### PR TITLE
Allow to use the default C header of the in-kernel SGX driver

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,7 @@ Additionally, this repository contains the script ``link-intel-driver.py`` to
 find and copy the required C header from the Intel SGX driver installed on the
 system. The supported versions of the Intel SGX driver are:
 
+- In-kernel SGX driver, only versions 32+ (https://lore.kernel.org/linux-sgx/20200716135303.276442-1-jarkko.sakkinen@linux.intel.com)
 - DCAP driver, newer versions 1.6+ (https://github.com/intel/SGXDataCenterAttestationPrimitives)
 - DCAP driver, older versions 1.5- (https://github.com/intel/SGXDataCenterAttestationPrimitives)
 - Older out-of-tree non-DCAP driver, only versions 1.9+ (https://github.com/intel/linux-sgx-driver)

--- a/link-intel-driver.py
+++ b/link-intel-driver.py
@@ -6,11 +6,14 @@ DRIVER_VERSIONS = {
         'sgx_user.h':                 '/dev/isgx',
         'include/uapi/asm/sgx.h':     '/dev/sgx',
         'include/uapi/asm/sgx_oot.h': '/dev/sgx/enclave',
+        'sgx_in_kernel.h':            '/dev/sgx/enclave',
 }
 
 def find_intel_sgx_driver():
     """
     Graphene only needs one header from the Intel SGX Driver:
+      - default sgx_in_kernel.h for in-kernel 32+ version of the driver
+        (https://lore.kernel.org/linux-sgx/20200716135303.276442-1-jarkko.sakkinen@linux.intel.com)
       - include/uapi/asm/sgx_oot.h for DCAP 1.6+ version of the driver
         (https://github.com/intel/SGXDataCenterAttestationPrimitives)
       - include/uapi/asm/sgx.h for DCAP 1.5- version of the driver
@@ -22,7 +25,12 @@ def find_intel_sgx_driver():
     """
     isgx_driver_path = os.getenv("ISGX_DRIVER_PATH")
     if not isgx_driver_path:
-        isgx_driver_path = os.path.expanduser(input('Enter the Intel SGX driver dir with C headers: '))
+        msg = 'Enter the Intel SGX driver dir with C headers (or press ENTER for in-kernel driver): '
+        isgx_driver_path = os.path.expanduser(input(msg))
+
+    if not isgx_driver_path or isgx_driver_path.strip() == '':
+        # user did not specify any driver path, use default in-kernel driver's C header
+        isgx_driver_path = os.path.dirname(os.path.abspath(__file__))
 
     for header_path, dev_path in DRIVER_VERSIONS.items():
         abs_header_path = os.path.abspath(os.path.join(isgx_driver_path, header_path))

--- a/sgx_in_kernel.h
+++ b/sgx_in_kernel.h
@@ -1,0 +1,118 @@
+/* SPDX-License-Identifier: (GPL-2.0 OR BSD-3-Clause) WITH Linux-syscall-note */
+/*
+ * Copyright(c) 2016-19 Intel Corporation.
+ */
+
+/* TODO: Graphene must remove this file after Intel SGX driver is upstreamed
+ *       and this header is distributed with the system */
+
+#ifndef _UAPI_ASM_X86_SGX_H
+#define _UAPI_ASM_X86_SGX_H
+
+#include <linux/types.h>
+#include <linux/ioctl.h>
+
+/**
+ * enum sgx_epage_flags - page control flags
+ * %SGX_PAGE_MEASURE:	Measure the page contents with a sequence of
+ *			ENCLS[EEXTEND] operations.
+ */
+enum sgx_page_flags {
+	SGX_PAGE_MEASURE	= 0x01,
+};
+
+#define SGX_MAGIC 0xA4
+
+#define SGX_IOC_ENCLAVE_CREATE \
+	_IOW(SGX_MAGIC, 0x00, struct sgx_enclave_create)
+#define SGX_IOC_ENCLAVE_ADD_PAGES \
+	_IOWR(SGX_MAGIC, 0x01, struct sgx_enclave_add_pages)
+#define SGX_IOC_ENCLAVE_INIT \
+	_IOW(SGX_MAGIC, 0x02, struct sgx_enclave_init)
+#define SGX_IOC_ENCLAVE_SET_ATTRIBUTE \
+	_IOW(SGX_MAGIC, 0x03, struct sgx_enclave_set_attribute)
+
+/**
+ * struct sgx_enclave_create - parameter structure for the
+ *                             %SGX_IOC_ENCLAVE_CREATE ioctl
+ * @src:	address for the SECS page data
+ */
+struct sgx_enclave_create  {
+	__u64	src;
+};
+
+/**
+ * struct sgx_enclave_add_pages - parameter structure for the
+ *                                %SGX_IOC_ENCLAVE_ADD_PAGE ioctl
+ * @src:	start address for the page data
+ * @offset:	starting page offset
+ * @length:	length of the data (multiple of the page size)
+ * @secinfo:	address for the SECINFO data
+ * @flags:	page control flags
+ * @count:	number of bytes added (multiple of the page size)
+ */
+struct sgx_enclave_add_pages {
+	__u64	src;
+	__u64	offset;
+	__u64	length;
+	__u64	secinfo;
+	__u64	flags;
+	__u64	count;
+};
+
+/**
+ * struct sgx_enclave_init - parameter structure for the
+ *                           %SGX_IOC_ENCLAVE_INIT ioctl
+ * @sigstruct:	address for the SIGSTRUCT data
+ */
+struct sgx_enclave_init {
+	__u64 sigstruct;
+};
+
+/**
+ * struct sgx_enclave_set_attribute - parameter structure for the
+ *				      %SGX_IOC_ENCLAVE_SET_ATTRIBUTE ioctl
+ * @attribute_fd:	file handle of the attribute file in the securityfs
+ */
+struct sgx_enclave_set_attribute {
+	__u64 attribute_fd;
+};
+
+/**
+ * struct sgx_enclave_exception - structure to report exceptions encountered in
+ *				  __vdso_sgx_enter_enclave()
+ *
+ * @leaf:	ENCLU leaf from \%eax at time of exception
+ * @trapnr:	exception trap number, a.k.a. fault vector
+ * @error_code:	exception error code
+ * @address:	exception address, e.g. CR2 on a #PF
+ * @reserved:	reserved for future use
+ */
+struct sgx_enclave_exception {
+	__u32 leaf;
+	__u16 trapnr;
+	__u16 error_code;
+	__u64 address;
+	__u64 reserved[2];
+};
+
+/**
+ * typedef sgx_enclave_exit_handler_t - Exit handler function accepted by
+ *					__vdso_sgx_enter_enclave()
+ *
+ * @rdi:	RDI at the time of enclave exit
+ * @rsi:	RSI at the time of enclave exit
+ * @rdx:	RDX at the time of enclave exit
+ * @ursp:	RSP at the time of enclave exit (untrusted stack)
+ * @r8:		R8 at the time of enclave exit
+ * @r9:		R9 at the time of enclave exit
+ * @tcs:	Thread Control Structure used to enter enclave
+ * @ret:	0 on success (EEXIT), -EFAULT on an exception
+ * @e:		Pointer to struct sgx_enclave_exception (as provided by caller)
+ */
+typedef int (*sgx_enclave_exit_handler_t)(long rdi, long rsi, long rdx,
+					  long ursp, long r8, long r9,
+					  void *tcs, int ret,
+					  struct sgx_enclave_exception *e);
+
+#endif /* _UAPI_ASM_X86_SGX_H */


### PR DESCRIPTION
This PR allows to use in-kernel Intel SGX driver. While building Graphene, the user must simply skip the prompt of the SGX driver's directory (by pressing ENTER).

This PR relies on the fact that the `ioctl` API of the Intel SGX driver v32+ doesn't change any more. So the PR simply uses the `sgx_in_kernel.h` copy-pasted from the in-kernel Intel SGX driver.

The corresponding PR is https://github.com/oscarlab/graphene/pull/1737.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-sgx-driver/27)
<!-- Reviewable:end -->
