### PR TITLE
[Build] Ignore .cache.mk file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Module.symvers
 modules.order
 .tmp_versions
 sgx.h
+.cache.mk


### PR DESCRIPTION
Building this module on newer kernels creates a temporary .cache.mk file.  This is cleaned up by 'make clean', but not ignored by git, causing CI failures on the gitignore check.  Add this to .gitignore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-sgx-driver/29)
<!-- Reviewable:end -->
