### PR TITLE
Remove support for older DCAP/in-kernel drivers that use /dev/sgx

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,8 +35,7 @@ find and copy the required C header from the Intel SGX driver installed on the
 system. The supported versions of the Intel SGX driver are:
 
 - In-kernel SGX driver, only versions 32+ (https://lore.kernel.org/linux-sgx/20200716135303.276442-1-jarkko.sakkinen@linux.intel.com)
-- DCAP driver, newer versions 1.6+ (https://github.com/intel/SGXDataCenterAttestationPrimitives)
-- DCAP driver, older versions 1.5- (https://github.com/intel/SGXDataCenterAttestationPrimitives)
+- DCAP driver, only versions 1.6+ (https://github.com/intel/SGXDataCenterAttestationPrimitives)
 - Older out-of-tree non-DCAP driver, only versions 1.9+ (https://github.com/intel/linux-sgx-driver)
 
 To install the Graphene SGX driver, please run:

--- a/link-intel-driver.py
+++ b/link-intel-driver.py
@@ -4,22 +4,22 @@ import sys, os, shutil
 
 DRIVER_VERSIONS = {
         'sgx_user.h':                 '/dev/isgx',
-        'include/uapi/asm/sgx.h':     '/dev/sgx',
         'include/uapi/asm/sgx_oot.h': '/dev/sgx/enclave',
+        'include/uapi/asm/sgx.h':     '/dev/sgx/enclave',
         'sgx_in_kernel.h':            '/dev/sgx/enclave',
 }
 
 def find_intel_sgx_driver():
     """
     Graphene only needs one header from the Intel SGX Driver:
-      - default sgx_in_kernel.h for in-kernel 32+ version of the driver
-        (https://lore.kernel.org/linux-sgx/20200716135303.276442-1-jarkko.sakkinen@linux.intel.com)
-      - include/uapi/asm/sgx_oot.h for DCAP 1.6+ version of the driver
-        (https://github.com/intel/SGXDataCenterAttestationPrimitives)
-      - include/uapi/asm/sgx.h for DCAP 1.5- version of the driver
-        (https://github.com/intel/SGXDataCenterAttestationPrimitives)
       - sgx_user.h for non-DCAP, older version of the driver
         (https://github.com/intel/linux-sgx-driver)
+      - include/uapi/asm/sgx_oot.h for DCAP 1.6+ version of the driver
+        (https://github.com/intel/SGXDataCenterAttestationPrimitives)
+      - include/uapi/asm/sgx.h for in-kernel 20+ version of the driver
+        (https://lore.kernel.org/linux-sgx/20190417103938.7762-1-jarkko.sakkinen@linux.intel.com/)
+      - default sgx_in_kernel.h for in-kernel 32+ version of the driver
+        (https://lore.kernel.org/linux-sgx/20200716135303.276442-1-jarkko.sakkinen@linux.intel.com)
 
     This function returns the required header from the SGX driver.
     """

--- a/sgx_in_kernel.h
+++ b/sgx_in_kernel.h
@@ -4,7 +4,10 @@
  */
 
 /* TODO: Graphene must remove this file after Intel SGX driver is upstreamed
- *       and this header is distributed with the system */
+ *       and this header is distributed with the system. This header was tested
+ *       with driver versions 32 and 36, it *may* be out of sync with newer
+ *       versions. If possible, use the header found on the system instead of
+ *       this one. */
 
 #ifndef _UAPI_ASM_X86_SGX_H
 #define _UAPI_ASM_X86_SGX_H


### PR DESCRIPTION
DCAP SGX drivers v1.5- and in-kernel SGX drivers v19- use SGX device `/dev/sgx` instead of of the newer `/dev/sgx/enclave`. Nobody uses these old versions these days, so remove support for them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-sgx-driver/30)
<!-- Reviewable:end -->
